### PR TITLE
Remove Nmap Full UDP Scan from attack plan

### DIFF
--- a/attackplan.ini
+++ b/attackplan.ini
@@ -17,12 +17,10 @@ Order: Nmap Fast TCP and UDP Plan,Nmap All TCP Ports Plan
 Order: Nmap Scan Fast TCP,Nmap Scan Fast UDP
 [Nmap All TCP Ports Plan]
 Order: Nmap Scan All TCP
-[Nmap All UDP Ports Plan]
-Order: Nmap Scan All UDP
 [Enumeration Plan]
 Order: Information Gathering,User Enumeration,Web Site Scanning,Password List Generation,User Enumeration Bruteforce
 [Post Enumeration Plan]
-Order: Metasploit Database Start,Metasploit Database Import,Metasploit Report Generation,Web Content Detection,Web Exploitation,Nmap HTTP Scan,Brute Forcing Lite,Vulnerablity Analysis,Vulnerability Validation,Web Site Nikto Tests,Brute Forcing,Nmap Scan All UDP
+Order: Metasploit Database Start,Metasploit Database Import,Metasploit Report Generation,Web Content Detection,Web Exploitation,Nmap HTTP Scan,Brute Forcing Lite,Vulnerablity Analysis,Vulnerability Validation,Web Site Nikto Tests,Brute Forcing
 
 #= Nmap Phases ============
 # The following sections detail the specific commands that will be run (found in the config.ini) at each nmap phase
@@ -34,8 +32,6 @@ always: Nmap Fast TCP
 always: Nmap Fast UDP
 [Nmap Scan All TCP]
 always: Nmap All TCP
-[Nmap Scan All UDP]
-always: Nmap All UDP
 
 #= Enumeration Phases ============
 # The following sections detail the specific commands that will be run (found in the config.ini) at each enumeration phase


### PR DESCRIPTION
Remove Full UDP NMap scan as part of the default attack plan; this type of scan takes an enourmously long amount of time to even finish and the results are flakey at best.